### PR TITLE
For Merge | Remove password storage from project config and fix sso redirect handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.7 - 2026-06-20
+### Added
+- To let the forum embed default when user login into plugin first time.
+
 ## 2.0.6 - 2024-09-03
 ### Added
 - Revise the plugin settings page to enhance user-friendliness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 2.0.7 - 2026-06-20
 ### Added
-- To let the forum embed default when user login into plugin first time.
+- Enable the forum embed by default for users when they log into the plugin for the first time.
 
 ## 2.0.6 - 2024-09-03
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "websitetoolbox/websitetoolboxcommunity",
     "description": "The Easiest CraftCMS Community Plugin. Effortlessly Build a Beautiful Community Forum with Zero Coding, Seamless Embedding, Instant Setup, and Exceptional Support.",
     "type": "craft-plugin",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "keywords": [
         "craft",
         "cms",

--- a/src/Websitetoolboxcommunity.php
+++ b/src/Websitetoolboxcommunity.php
@@ -125,7 +125,7 @@ class Websitetoolboxcommunity extends Plugin{
                 // A case when web page redirect before dologin img loads
                 Event::on(\yii\web\Response::class, \yii\web\Response::EVENT_BEFORE_SEND, function($event) {
                     $response = $event->sender;
-                    if($response->statusCode === 302 && isset($_COOKIE['forumLogoutToken']) && Craft::$app->getSession()->get(Craft::$app->getUser()->tokenParam) && !isset($_COOKIE['ssoCompletedAfterPageRedirect'])){
+                    if($response->statusCode === 302 && $this->checkGroupPermission() && isset($_COOKIE['forumLogoutToken']) && Craft::$app->getSession()->get(Craft::$app->getUser()->tokenParam) && !isset($_COOKIE['ssoCompletedAfterPageRedirect'])){
                         $this->printLogoutImgTag($_COOKIE['forumLogoutToken']);
                         setcookie('ssoCompletedAfterPageRedirect', 1, time() + (86400 * 365),"/");    
                         $_COOKIE['ssoCompletedAfterPageRedirect'] = 1;
@@ -243,27 +243,16 @@ class Websitetoolboxcommunity extends Plugin{
                 Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumEmbedded', 1);
                 Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.communityUrl', $embeddedPage);
             }else{
-                $embeddedPage = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.communityUrl','');
-                if(isset($_POST['settings']['forumEmbedded'])){
-                    Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumEmbedded', $_POST['settings']['forumEmbedded']);
-                }
+                $configFields = ['forumEmbedded', 'communityUrl', 'ssoSetting', 'userGroupsId'];
+                $pluginSettings = $this->preserveConfigFields($configFields); 
+                $embeddedPage = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.communityUrl', '') ?: $pluginSettings["communityUrl"] ?? '';                
             }
             $forumAddress = $result->forumAddress;
             $forumApiKey = $result->forumApiKey;
         } else{
-            $preserveFields = [
-                'savedForumUsername' => 'forumUsername',
-                'secretKey'          => 'secretKey',
-                'ssoSetting'         => 'ssoSetting',
-                'userGroupsId'       => 'userGroupsId',
-            ];
-            foreach($preserveFields as $postKey => $configKey){
-                $value = $_POST['settings'][$postKey] ?? '';
-                if($value){
-                    Craft::$app->getProjectConfig()->set("plugins.websitetoolboxforum.settings.{$configKey}", $value);
-                }
-            }
-            $userName = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumUsername', '') ?: Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum')["settings"]["forumUsername"] ?? '';
+            $configFields = ['ssoSetting', 'userGroupsId', 'forumUsername', 'secretKey'];
+            $pluginSettings = $this->preserveConfigFields($configFields);
+            $userName = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumUsername', '') ?: $pluginSettings["forumUsername"] ?? '';
             $embedOption = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumEmbedded',false);
             if(isset($_POST['settings']['sso_setting'])){
                 $ssoSetting = trim($_POST['settings']['sso_setting']);
@@ -448,5 +437,17 @@ class Websitetoolboxcommunity extends Plugin{
         $forumUrl = Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum') ["settings"]["forumUrl"];
         echo '<img src='.$forumUrl.'/register/logout?authtoken='.$token.'" border="0" width="1" height="1" alt="" id="logout_img">';
         Websitetoolboxcommunity::getInstance()->sso->resetCookieOnLogout();
+    }
+    public function preserveConfigFields(array $configFields): array
+    {
+        $pluginSettings = Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum')["settings"];
+        foreach($configFields as $configKey){
+            $value = Craft::$app->getProjectConfig()->get("plugins.websitetoolboxforum.settings.{$configKey}", '') ?: $pluginSettings[$configKey] ?? '';
+            if ($configKey == 'ssoSetting' && $value == "") {
+                $value = "all_users";
+            }
+            Craft::$app->getProjectConfig()->set("plugins.websitetoolboxforum.settings.{$configKey}", $value);
+        }
+        return $pluginSettings;
     }
 }

--- a/src/Websitetoolboxcommunity.php
+++ b/src/Websitetoolboxcommunity.php
@@ -203,9 +203,7 @@ class Websitetoolboxcommunity extends Plugin{
             $webhookUrl = $siteUrl.'?'.$pageTrigger.'='.$webHookPage;
         }
         if(isset($_POST['settings']['forumUsername'])){ 
-            $forumType  = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumEmbedded',false);
-            $forumUrl  = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumUrl',false);
-            $ssoSetting = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.ssoSetting',false);
+            $forumApiKey = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumApiKey','');
             $userName               = $_POST['settings']['forumUsername'];
             $userPassword           = $_POST['settings']['forumPassword'];
             $postData = array('action' => 'checkPluginLogin', 'username' => $userName,'password'=>$userPassword, 'plugin' => 'craft', 'websiteBuilder' => 'craftcms', 'pluginWebhookUrl' => $webhookUrl);           
@@ -222,24 +220,31 @@ class Websitetoolboxcommunity extends Plugin{
             }
             $deleteForumUrlRows     = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUrl');
             $deleteForumApiKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumApiKey');            
+            $deleteForumUsernameRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUsername');
+            $deleteForumPasswordRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumPassword');
 
             $affectedForumUrlRows   = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUrl',$result->forumAddress); 
-            $affectedForumApiKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumApiKey',$result->forumApiKey);            
+            $affectedForumApiKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumApiKey',$result->forumApiKey);
+            $affectedForumUsernameRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUsername', $userName);
+            $affectedForumPasswordRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumPassword', $userPassword);            
             if(isset($result->secretKey)){
                 $deleteSecretKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.secretKey');
                 $affectedSecretKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.secretKey', $result->secretKey);
             }
-            if($forumUrl !='' && $forumType ==''){
-                $embeddedPage = '';
-            }else{
+            if($forumApiKey == ''){
                 $embeddedPage = 'community';
-            }
-            if($ssoSetting == ''){                
                 $this->setUserGroupAccess('all_users');
+                Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumEmbedded', 1);
+                Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.communityUrl', $embeddedPage);
+            }else{
+                $embeddedPage = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.communityUrl','');
+                if(isset($_POST['settings']['forumEmbedded'])){
+                    Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumEmbedded', $_POST['settings']['forumEmbedded']);
+                }
             }
         } else{
-            $userName = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumUsername',false);
-            $userPassword = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumPassword',false);
+            $userName = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumUsername', '') ?: Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum')["settings"]["forumUsername"] ?? '';
+            $userPassword = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumPassword', '') ?: Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum')["settings"]["forumPassword"] ?? '';
             $embedOption = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumEmbedded',false);
             if(isset($_POST['settings']['sso_setting'])){
                 $ssoSetting = trim($_POST['settings']['sso_setting']);
@@ -256,7 +261,7 @@ class Websitetoolboxcommunity extends Plugin{
             }else{
                 $embeddedPage = '';
             }
-            $postData = array('action' => 'checkPluginLogin', 'username' => $userName,'password'=>$userPassword, 'plugin' => 'craft', 'websiteBuilder' => 'craftcms', 'pluginWebhookUrl' => $webhookUrl);            
+            $postData = array('action' => 'checkPluginLogin', 'username' => $userName,'password'=>$userPassword, 'plugin' => 'craft', 'websiteBuilder' => 'craftcms', 'pluginWebhookUrl' => $webhookUrl);
             $result = $this->sso->sendApiRequest('POST',WT_SETTINGS_URL,$postData,'json');
             if(empty($result) || (isset($result->errorMessage) && $result->errorMessage != '')){
                 if(empty($result)){
@@ -269,10 +274,14 @@ class Websitetoolboxcommunity extends Plugin{
                 exit;
             }
             $deleteForumUrlRows     = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUrl');
-            $deleteForumApiKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumApiKey');                  
+            $deleteForumApiKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumApiKey');
+            $deleteForumUsernameRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUsername');
+            $deleteForumPasswordRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumPassword');
 
             $affectedForumUrlRows   = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUrl',$result->forumAddress); 
             $affectedForumApiKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumApiKey',$result->forumApiKey);
+            $affectedForumUsernameRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUsername', $userName);
+            $affectedForumPasswordRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumPassword', $userPassword);
             if(isset($result->secretKey)){                
                 $deleteSecretKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.secretKey');
                 $affectedSecretKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.secretKey', $result->secretKey);

--- a/src/Websitetoolboxcommunity.php
+++ b/src/Websitetoolboxcommunity.php
@@ -41,7 +41,7 @@ define('WT_SETTINGS_URL', 'https://www.websitetoolbox.com/tool/members/mb/settin
  */
 class Websitetoolboxcommunity extends Plugin{
     public static $plugin;
-    public static $craft31 = false;    
+    public static $craft31 = false;
     public $connection; 
     
     // Public Methods
@@ -116,11 +116,20 @@ class Websitetoolboxcommunity extends Plugin{
                         }else{                        
                             $jsRender = Websitetoolboxcommunity::getInstance()->sso->renderJsScriptEmbedded($forumUrl,'loggedout');
                         }
-                    }else{                    
+                    }else{
                         $jsRender = Websitetoolboxcommunity::getInstance()->sso->renderJsScriptUnEmbedded();
                     }                                
                     $view = Craft::$app->getView();
                     $view->registerJs($jsRender);
+                });
+                // A case when web page redirect before dologin img loads
+                Event::on(\yii\web\Response::class, \yii\web\Response::EVENT_BEFORE_SEND, function($event) {
+                    $response = $event->sender;
+                    if($response->statusCode === 302 && isset($_COOKIE['forumLogoutToken']) && Craft::$app->getSession()->get(Craft::$app->getUser()->tokenParam) && !isset($_COOKIE['ssoCompletedAfterPageRedirect'])){
+                        $this->printLogoutImgTag($_COOKIE['forumLogoutToken']);
+                        setcookie('ssoCompletedAfterPageRedirect', 1, time() + (86400 * 365),"/");    
+                        $_COOKIE['ssoCompletedAfterPageRedirect'] = 1;
+                    }
                 });
                 if(!empty(Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum') ["settings"]["communityUrl"])){
                     // Register site url route for community

--- a/src/Websitetoolboxcommunity.php
+++ b/src/Websitetoolboxcommunity.php
@@ -215,7 +215,7 @@ class Websitetoolboxcommunity extends Plugin{
             $forumApiKey = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumApiKey','');
             $userName               = $_POST['settings']['forumUsername'];
             $userPassword           = $_POST['settings']['forumPassword'];
-            $postData = array('action' => 'checkPluginLogin', 'username' => $userName,'password'=>$userPassword, 'plugin' => 'craft', 'websiteBuilder' => 'craftcms', 'pluginWebhookUrl' => $webhookUrl);           
+            $postData = array('action' => 'checkPluginLogin', 'username' => $userName,'password'=>$userPassword, 'plugin' => 'craft', 'websiteBuilder' => 'craftcms', 'pluginWebhookUrl' => $webhookUrl);
             $result = $this->sso->sendApiRequest('POST',WT_SETTINGS_URL,$postData,'json');
             if(empty($result) || (isset($result->errorMessage) && $result->errorMessage != '')){
                 if(empty($result)){
@@ -230,12 +230,9 @@ class Websitetoolboxcommunity extends Plugin{
             $deleteForumUrlRows     = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUrl');
             $deleteForumApiKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumApiKey');            
             $deleteForumUsernameRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUsername');
-            $deleteForumPasswordRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumPassword');
-
             $affectedForumUrlRows   = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUrl',$result->forumAddress); 
             $affectedForumApiKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumApiKey',$result->forumApiKey);
             $affectedForumUsernameRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUsername', $userName);
-            $affectedForumPasswordRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumPassword', $userPassword);            
             if(isset($result->secretKey)){
                 $deleteSecretKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.secretKey');
                 $affectedSecretKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.secretKey', $result->secretKey);
@@ -251,9 +248,22 @@ class Websitetoolboxcommunity extends Plugin{
                     Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumEmbedded', $_POST['settings']['forumEmbedded']);
                 }
             }
+            $forumAddress = $result->forumAddress;
+            $forumApiKey = $result->forumApiKey;
         } else{
+            $preserveFields = [
+                'savedForumUsername' => 'forumUsername',
+                'secretKey'          => 'secretKey',
+                'ssoSetting'         => 'ssoSetting',
+                'userGroupsId'       => 'userGroupsId',
+            ];
+            foreach($preserveFields as $postKey => $configKey){
+                $value = $_POST['settings'][$postKey] ?? '';
+                if($value){
+                    Craft::$app->getProjectConfig()->set("plugins.websitetoolboxforum.settings.{$configKey}", $value);
+                }
+            }
             $userName = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumUsername', '') ?: Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum')["settings"]["forumUsername"] ?? '';
-            $userPassword = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumPassword', '') ?: Craft::$app->getPlugins()->getStoredPluginInfo('websitetoolboxforum')["settings"]["forumPassword"] ?? '';
             $embedOption = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumEmbedded',false);
             if(isset($_POST['settings']['sso_setting'])){
                 $ssoSetting = trim($_POST['settings']['sso_setting']);
@@ -270,35 +280,15 @@ class Websitetoolboxcommunity extends Plugin{
             }else{
                 $embeddedPage = '';
             }
-            $postData = array('action' => 'checkPluginLogin', 'username' => $userName,'password'=>$userPassword, 'plugin' => 'craft', 'websiteBuilder' => 'craftcms', 'pluginWebhookUrl' => $webhookUrl);
-            $result = $this->sso->sendApiRequest('POST',WT_SETTINGS_URL,$postData,'json');
-            if(empty($result) || (isset($result->errorMessage) && $result->errorMessage != '')){
-                if(empty($result)){
-                    $errorMessage = 'Authentication fail for Websitetoolboxcommunity';
-                }else{
-                    $errorMessage = $result->errorMessage;
-                }
-                Craft::$app->getSession()->setNotice(Craft::t('websitetoolboxforum', $errorMessage));
-                Craft::$app->getResponse()->redirect(UrlHelper::cpUrl('settings/plugins/websitetoolboxforum'))->send();
-                exit;
+            if(isset($_POST['settings']['forumEmbedded'])){
+                Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumEmbedded', $_POST['settings']['forumEmbedded']);
             }
-            $deleteForumUrlRows     = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUrl');
-            $deleteForumApiKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumApiKey');
-            $deleteForumUsernameRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumUsername');
-            $deleteForumPasswordRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.forumPassword');
-
-            $affectedForumUrlRows   = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUrl',$result->forumAddress); 
-            $affectedForumApiKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumApiKey',$result->forumApiKey);
-            $affectedForumUsernameRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumUsername', $userName);
-            $affectedForumPasswordRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.forumPassword', $userPassword);
-            if(isset($result->secretKey)){                
-                $deleteSecretKeyRows  = Craft::$app->getProjectConfig()->remove('plugins.websitetoolboxforum.settings.secretKey');
-                $affectedSecretKeyRows = Craft::$app->getProjectConfig()->set('plugins.websitetoolboxforum.settings.secretKey', $result->secretKey);
-            }
-        }        
-        $this->setAuthToken($result->forumAddress, $result->forumApiKey);
+            $forumAddress = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumUrl', '');
+            $forumApiKey = Craft::$app->getProjectConfig()->get('plugins.websitetoolboxforum.settings.forumApiKey', '');
+        }
+        $this->setAuthToken($forumAddress, $forumApiKey);
         // to set embedded url
-        $this->updateEmbeddedUrl($userName, $result->forumApiKey, $embeddedPage);
+        $this->updateEmbeddedUrl($userName, $forumApiKey, $embeddedPage);
         Craft::$app->getResponse()->redirect(UrlHelper::cpUrl('settings/plugins/websitetoolboxforum'))->send();
     }
     /**

--- a/src/config.php
+++ b/src/config.php
@@ -17,8 +17,6 @@
 return [
         // Websitetoolbox Forums Username
         'forumUsername' => '',
-        // Websitetoolbox Forums Password
-        'forumPassword' => '',
         //Embedded Forum or Non-Embedded Forum
         'forumEmbedded' => '',
 ];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -20,7 +20,6 @@ use craft\helpers\UrlHelper;
 class Settings extends Model{
     // Public Properties    
     public $forumUsername         = '';
-    public $forumPassword         = '';
     public $forumEmbedded         = 1;
     public $forumApiKey           = '';
     public $forumUrl              = '';  
@@ -59,7 +58,7 @@ class Settings extends Model{
     /**   * @inheritdoc     */
     public function rules(): array{
         return [
-            [['forumUsername', 'forumPassword'], 'required'],
+            [['forumUsername'], 'required'],
             [['forumApiKey','forumUrl'], 'string'],
             ['communityUrl', 'validateUrl']
         ];
@@ -78,7 +77,6 @@ class Settings extends Model{
                 'class' => EnvAttributeParserBehavior::class,
                 'attributes' => [
                     'forumUsername',
-                    'forumPassword',
                     'forumApiKey',
                     'forumUrl',
                     'communityUrl'

--- a/src/services/Sso.php
+++ b/src/services/Sso.php
@@ -170,7 +170,8 @@ class Sso extends Component{
       setcookie('forumLoginUserid', '', time() - (86400 * 365), "/");
       setcookie('forumAddress', '', time() - (86400 * 365), "/");
       setcookie('logInForum', '', time() - 3600, "/");
-   } 
+      setcookie('ssoCompletedAfterPageRedirect', '', time() - 3600, "/");
+   }
    /**
     * @uses function to get user groups ids of logged in user.
     */

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -23,10 +23,6 @@
 <table class='wt_setting_table'>
     {% if (craft.app.getPlugins.getStoredPluginInfo('websitetoolboxforum') ["settings"]["forumUsername"] is  not defined) or (craft.app.request.getParam('communitySettingOption') == 1)  %}     
         {% set afterSettingSavedPage = 0 %}
-        <input type="hidden" name="forumEmbedded" value="{{ settings.forumEmbedded }}">
-        <input type="hidden" name="communityUrl" value="{{ settings.communityUrl }}">
-        <input type="hidden" name="sso_setting" value="{{ settings.ssoSetting }}">
-        <input type="hidden" name="userGroupsId" value="{{ settings.userGroupsId }}">
         <tr>
             <td>                
                 <b>Please log in to your Website Toolbox account.</b>
@@ -103,7 +99,6 @@
             </td>
             <td>                
                 {{craft.app.getPlugins.getStoredPluginInfo('websitetoolboxforum') ["settings"]["forumUsername"]}}<a href="{{ craft.app.request.absoluteUrl }}{{ '?' in craft.app.request.absoluteUrl ? '&' : '?' }}communitySettingOption=1" class="change_link">Change</a>
-                <input type="hidden" name="savedForumUsername" value="{{ settings.forumUsername }}">
             </td>
         </tr>
         <tr>
@@ -249,9 +244,6 @@
                     </div>
                 </td>
             </tr>
-        {% else %}
-            <input type="hidden" name="sso_setting" value="{{ settings.ssoSetting ? settings.ssoSetting : "all_users"  }}">
-            <input type="hidden" name="userGroupsId" value="{{ settings.userGroupsId }}">
         {% endif %}
     {% endif %}
     <tr>
@@ -281,7 +273,6 @@
                     class: "d_none"
                 })
             }}
-            <input type="hidden" name="secretKey" value="{{ craft.app.projectConfig.get('plugins.websitetoolboxforum.settings.secretKey') }}">
             {% if (afterSettingSavedPage)  %}
                 <b>Be sure to specify your sign up, log in, and log out page addresses in the <a href="https://www.websitetoolbox.com/tool/members/mb/settings?tab=Single Sign On"> Single Sign On section </a>of Website Toolbox.</b>
             {% endif %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -23,6 +23,10 @@
 <table class='wt_setting_table'>
     {% if (craft.app.getPlugins.getStoredPluginInfo('websitetoolboxforum') ["settings"]["forumUsername"] is  not defined) or (craft.app.request.getParam('communitySettingOption') == 1)  %}     
         {% set afterSettingSavedPage = 0 %}
+        <input type="hidden" name="forumEmbedded" value="{{ settings.forumEmbedded }}">
+        <input type="hidden" name="communityUrl" value="{{ settings.communityUrl }}">
+        <input type="hidden" name="sso_setting" value="{{ settings.ssoSetting }}">
+        <input type="hidden" name="userGroupsId" value="{{ settings.userGroupsId }}">
         <tr>
             <td>                
                 <b>Please log in to your Website Toolbox account.</b>
@@ -98,7 +102,7 @@
                 <b class="pull_right">Account</b> 
             </td>
             <td>                
-                {{craft.app.getPlugins.getStoredPluginInfo('websitetoolboxforum') ["settings"]["forumUsername"]}}<a href="{{ craft.app.request.absoluteUrl }}&communitySettingOption=1" class="change_link">Change</a>
+                {{craft.app.getPlugins.getStoredPluginInfo('websitetoolboxforum') ["settings"]["forumUsername"]}}<a href="{{ craft.app.request.absoluteUrl }}{{ '?' in craft.app.request.absoluteUrl ? '&' : '?' }}communitySettingOption=1" class="change_link">Change</a>
             </td>
         </tr>
         <tr>

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -57,7 +57,7 @@
                     "label": "Website Toolbox Password"|t("websitetoolboxcommunity"),
                     "id": "forumPassword",
                     "name": "forumPassword",
-                    "value": settings.forumPassword,
+                    "value": "",
                     "required": true
                    })
                 }}
@@ -103,6 +103,7 @@
             </td>
             <td>                
                 {{craft.app.getPlugins.getStoredPluginInfo('websitetoolboxforum') ["settings"]["forumUsername"]}}<a href="{{ craft.app.request.absoluteUrl }}{{ '?' in craft.app.request.absoluteUrl ? '&' : '?' }}communitySettingOption=1" class="change_link">Change</a>
+                <input type="hidden" name="savedForumUsername" value="{{ settings.forumUsername }}">
             </td>
         </tr>
         <tr>
@@ -180,7 +181,7 @@
 ]]></style><g><path class="st0" d="M97.67,20.81L97.67,20.81l0.01,0.02c3.7,0.01,7.04,1.51,9.46,3.93c2.4,2.41,3.9,5.74,3.9,9.42h0.02v0.02v75.28 v0.01h-0.02c-0.01,3.68-1.51,7.03-3.93,9.46c-2.41,2.4-5.74,3.9-9.42,3.9v0.02h-0.02H38.48h-0.01v-0.02 c-3.69-0.01-7.04-1.5-9.46-3.93c-2.4-2.41-3.9-5.74-3.91-9.42H25.1c0-25.96,0-49.34,0-75.3v-0.01h0.02 c0.01-3.69,1.52-7.04,3.94-9.46c2.41-2.4,5.73-3.9,9.42-3.91v-0.02h0.02C58.22,20.81,77.95,20.81,97.67,20.81L97.67,20.81z M0.02,75.38L0,13.39v-0.01h0.02c0.01-3.69,1.52-7.04,3.93-9.46c2.41-2.4,5.74-3.9,9.42-3.91V0h0.02h59.19 c7.69,0,8.9,9.96,0.01,10.16H13.4h-0.02v-0.02c-0.88,0-1.68,0.37-2.27,0.97c-0.59,0.58-0.96,1.4-0.96,2.27h0.02v0.01v3.17 c0,19.61,0,39.21,0,58.81C10.17,83.63,0.02,84.09,0.02,75.38L0.02,75.38z M100.91,109.49V34.2v-0.02h0.02 c0-0.87-0.37-1.68-0.97-2.27c-0.59-0.58-1.4-0.96-2.28-0.96v0.02h-0.01H38.48h-0.02v-0.02c-0.88,0-1.68,0.38-2.27,0.97 c-0.59,0.58-0.96,1.4-0.96,2.27h0.02v0.01v75.28v0.02h-0.02c0,0.88,0.38,1.68,0.97,2.27c0.59,0.59,1.4,0.96,2.27,0.96v-0.02h0.01 h59.19h0.02v0.02c0.87,0,1.68-0.38,2.27-0.97c0.59-0.58,0.96-1.4,0.96-2.27L100.91,109.49L100.91,109.49L100.91,109.49 L100.91,109.49z"/></g></svg>
                         </span></a>
                     </div>
-                    <a href="{{ settings.forumUrl }}/tool/members/domain?tool=mb" class="change_link mt_5">Change</a> 
+                    <a href="{{ settings.forumUrl }}/tool/members/domain?tool=mb" class="change_link mt_5">Change</a>                    
                 </div>
                 {{ _self.errorList(settings.getErrors('communityUrl')) }}
                 <span><a id="copyLinkText">Copy the address</a> above and add a link to it in the website’s navigation menu.<a id="frmUrl" href="#" class="d_none">{{ baseUrl }}{% if backwardSlashVisibility == '' %}/{% endif %}{{ settings.communityUrl }}</a></span>
@@ -248,6 +249,9 @@
                     </div>
                 </td>
             </tr>
+        {% else %}
+            <input type="hidden" name="sso_setting" value="{{ settings.ssoSetting ? settings.ssoSetting : "all_users"  }}">
+            <input type="hidden" name="userGroupsId" value="{{ settings.userGroupsId }}">
         {% endif %}
     {% endif %}
     <tr>
@@ -277,6 +281,7 @@
                     class: "d_none"
                 })
             }}
+            <input type="hidden" name="secretKey" value="{{ craft.app.projectConfig.get('plugins.websitetoolboxforum.settings.secretKey') }}">
             {% if (afterSettingSavedPage)  %}
                 <b>Be sure to specify your sign up, log in, and log out page addresses in the <a href="https://www.websitetoolbox.com/tool/members/mb/settings?tab=Single Sign On"> Single Sign On section </a>of Website Toolbox.</b>
             {% endif %}


### PR DESCRIPTION
For Merge
----------------------------
### Why

Storing the Website Toolbox login password directly in the site's configuration file was a security concern. The password was only needed briefly during the initial account connection, so persisting it long-term was unnecessary and risky. Additionally, when users were redirected immediately after logging in, the single sign-on process would sometimes fail because the login step didn't have time to complete before the page navigated away.

### What Changed

- The Website Toolbox login password is no longer saved in the site configuration after initial setup. It is only used momentarily to authenticate, and the connection token received in return is stored instead.
- When a site admin saves settings (like changing the embedded mode, community URL, or single sign-on options) without re-entering their Website Toolbox password, all previously saved settings now remain intact and are not wiped or reset.
- The embedded forum setting now defaults to enabled automatically when an admin first connects their Website Toolbox account, so the forum appears embedded on the site right away without requiring a second save.
- When a page redirects immediately after a user logs in (for example, a welcome redirect), the single sign-on logout synchronization now fires properly so the community forum state stays consistent with the main site login state.
- The "Change" link on the settings page now works correctly regardless of whether the current page URL already contains query parameters.

### QA

- **Affected URLs**: Craft CMS admin settings page at `/admin/settings/plugins/websitetoolboxforum`
- **Setup Requirements**: A Website Toolbox community account. Install the plugin on a Craft CMS 4 site.
- **Verification Steps**:
  1. **First-time setup**: Install the plugin, enter Website Toolbox username and password on the settings page, and save. Confirm the forum connects successfully, the embedded checkbox is checked by default, and the community URL is set to "community".
  2. **Password not stored**: After saving, check the project configuration file and confirm the login password is not present anywhere in it.
  3. **Settings update preserves data**: Without re-entering a password, change the embedded checkbox or community URL and save. Confirm the username, API key, forum URL, and secret key all remain unchanged.
  4. **SSO redirect**: Log into the Craft CMS site where the user is immediately redirected to another page (e.g., via a plugin or config). Confirm the forum login state matches the site login state and no errors appear.
  5. **Change link**: On the settings page, click the "Change" link next to the account name. Confirm it navigates correctly and the password form appears.
  
**Important Notes**
-----------------
QA reported mantis [#30058](https://www.websitetoolbox.com/mantis/view.php?id=30058).
**Scenario:** Go to forum admin section -> change  the domain -> now update the
plugin settings(2nd page) -> now check the updated domain in the forum.

Actual Result: Domain is not updating in the forum when saving the plugin
settings.
Expected Result: Domain should be updated in the forum when we updating plugin
settings.

As discussed with QA(Gopal & Shruti) team we can work on this issue in separate branch.